### PR TITLE
updated readme (login)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,8 @@ docker push agentejo/cockpit
 # Run
 docker run -p 8080:80 agentejo/cockpit:latest
 
+# Login
+You can find the default user and password at URL [/install](http://localhost:8080/install)
+
 # Cleanup
 docker rmi $(docker images -f "dangling=true" -q) agentejo/cockpit:latest -f


### PR DESCRIPTION
added where to find login informations so user of cockpit-docker can immediately start with it.
Otherwise they have to search for it (like I) e.g. in Issues.