### PR TITLE
Fix #8 by removing volume configuration for config directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN chown -R www-data:www-data /var/www/html
 COPY ./entrypoint /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint
 
-VOLUME ["/var/www/html/storage", "/var/www/html/config"]
+VOLUME ["/var/www/html/storage"]
 
 ENTRYPOINT ["entrypoint"]
 CMD ["apache2-foreground"]


### PR DESCRIPTION
This removes the volume configuration for the config directory from the Dockerfile.

This shouldn't break anything. It's still possible to mount a volume with the configurations, but this also allows for scenarios where people want to build their own image and add configuration files from their Dockerfile.